### PR TITLE
more efficient implementation for multi source reachability

### DIFF
--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -1905,6 +1905,14 @@ class GraphAnalyzer:
             return center_point
         return [center_point]
 
+    class DummyRootNode:
+        """
+        Dummy root node class for shortest path calculations.
+
+        This class is used as a root node for shortest path calculations to prevent
+        duplicative searching when the same node is within range of multiple source nodes.
+        """
+
     def _compute_nodes_within_distance(
         self,
         graph: nx.Graph | nx.MultiGraph,
@@ -1952,17 +1960,27 @@ class GraphAnalyzer:
             nearest_node = self._get_nearest_node(point, nodes_gdf, node_id_name)
             source_nodes.append(nearest_node)
 
-        # Compute single-source shortest paths from all sources
-        all_reachable = set()
-        for source in source_nodes:
-            lengths = nx.single_source_dijkstra_path_length(
-                graph,
-                source,
-                cutoff=distance,
-                weight=edge_attr,
-            )
-            all_reachable.update(lengths.keys())
-        return all_reachable
+        # run a single-source shortest path from a dummy root node
+        # dummy root node prevents duplicative searching when the same node is within range of multiple source nodes
+
+        root = self.DummyRootNode()
+        graph.add_weighted_edges_from(
+            ((root, source, 0) for source in source_nodes), weight=edge_attr
+        )
+
+        lengths = nx.single_source_dijkstra_path_length(
+            graph,
+            root,
+            cutoff=distance,
+            weight=edge_attr,
+        )
+
+        # restore the original graph
+        graph.remove_node(root)
+
+        reachable = set(lengths.keys())
+        reachable.remove(root)
+        return reachable
 
     def _get_nearest_node(
         self,


### PR DESCRIPTION
add a dummy node to start of dijkstra search path(s) combines multiple runs of search into one single run of the algorithm

in the case of multiple overlapping search regions, removes deduplication step
each node is evaluated only once
unified boundary remains identical

in the case of non ovelapping search regions,
removes deduplication step

in the case of single search origin,
only adds 1 hop to start of search

## Description

What is the purpose of this pull request? Please provide a detailed description of the changes, including the problem it solves and the approach taken.

## Related Issues

Is this pull request related to any existing issues? If so, please link them here. For example, `Fixes #123` or `Closes #456`.

## Checklist

- [ ] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Pre-commit checks passed locally.
